### PR TITLE
Add tooltip shadow to line chart

### DIFF
--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1041,6 +1041,9 @@ class LineTouchTooltipData with EquatableMixin {
     this.showOnTopOfTheChartBoxArea = false,
     this.rotateAngle = 0.0,
     this.tooltipBorder = BorderSide.none,
+    this.shadowColor = Colors.transparent,
+    this.shadowBlur = 5,
+    this.shadowOffset = Offset.zero,
   });
 
   /// Sets a rounded radius for the tooltip.
@@ -1082,6 +1085,15 @@ class LineTouchTooltipData with EquatableMixin {
   // /// Retrieves data for setting background color of the tooltip.
   final GetLineTooltipColor getTooltipColor;
 
+  /// The shadow color of the tooltip.
+  final Color shadowColor;
+
+  /// The sigma value of shadow blur of the tooltip.
+  final double shadowBlur;
+
+  /// The shadow offset of the tooltip.
+  final Offset shadowOffset;
+
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props => [
@@ -1098,6 +1110,9 @@ class LineTouchTooltipData with EquatableMixin {
         rotateAngle,
         tooltipBorder,
         getTooltipColor,
+        shadowColor,
+        shadowBlur,
+        shadowOffset,
       ];
 }
 

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -45,6 +45,10 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       ..style = PaintingStyle.stroke
       ..color = Colors.transparent
       ..strokeWidth = 1.0;
+
+    _shadowTouchTooltipPaint = Paint()
+      ..style = PaintingStyle.fill
+      ..color = Colors.black;
   }
   late Paint _barPaint;
   late Paint _barAreaPaint;
@@ -53,6 +57,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
   late Paint _touchLinePaint;
   late Paint _bgTouchTooltipPaint;
   late Paint _borderTouchTooltipPaint;
+  late Paint _shadowTouchTooltipPaint;
 
   /// Paints [LineChartData] into the provided canvas.
   @override

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -1130,6 +1130,10 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       bottomLeft: radius,
       bottomRight: radius,
     );
+    final shadowRoundedRect = RRect.fromRectAndRadius(
+      rect.shift(tooltipData.shadowOffset),
+      radius,
+    );
 
     var topSpot = showingTooltipSpots.showingSpots[0];
     for (final barSpot in showingTooltipSpots.showingSpots) {
@@ -1139,6 +1143,12 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
     }
 
     _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(topSpot);
+    _shadowTouchTooltipPaint
+      ..color = tooltipData.shadowColor
+      ..maskFilter = MaskFilter.blur(
+        BlurStyle.normal,
+        tooltipData.shadowBlur,
+      );
 
     final rotateAngle = tooltipData.rotateAngle;
     final rectRotationOffset =
@@ -1161,6 +1171,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       angle: rotateAngle,
       drawCallback: () {
         canvasWrapper
+          ..drawRRect(shadowRoundedRect, _shadowTouchTooltipPaint)
           ..drawRRect(roundedRect, _bgTouchTooltipPaint)
           ..drawRRect(roundedRect, _borderTouchTooltipPaint);
       },

--- a/test/chart/line_chart/line_chart_painter_test.dart
+++ b/test/chart/line_chart/line_chart_painter_test.dart
@@ -2464,16 +2464,27 @@ void main() {
 
       final result1 =
           verify(mockCanvasWrapper.drawRRect(captureAny, captureAny))
-            ..called(2);
-      final rRect = result1.captured[0] as RRect;
-      final paint = result1.captured[1] as Paint;
+            ..called(3);
+      final rRectShadow = result1.captured[0] as RRect;
+      final paintShadow = result1.captured[1] as Paint;
+      expect(
+        rRectShadow,
+        RRect.fromLTRBR(0, 40, 38, 78, const Radius.circular(12)),
+      );
+      expect(paintShadow.color, const Color(0x00000000));
+      expect(
+        paintShadow.maskFilter,
+        const MaskFilter.blur(BlurStyle.normal, 5),
+      );
+      final rRect = result1.captured[2] as RRect;
+      final paint = result1.captured[3] as Paint;
       expect(
         rRect,
         RRect.fromLTRBR(0, 40, 38, 78, const Radius.circular(12)),
       );
       expect(paint.color, const Color(0x11111111));
-      final rRectBorder = result1.captured[2] as RRect;
-      final paintBorder = result1.captured[3] as Paint;
+      final rRectBorder = result1.captured[4] as RRect;
+      final paintBorder = result1.captured[5] as Paint;
       expect(
         rRectBorder,
         RRect.fromLTRBR(0, 40, 38, 78, const Radius.circular(12)),
@@ -2519,6 +2530,7 @@ void main() {
               .toList();
         },
         tooltipBorder: const BorderSide(color: Color(0x11111111), width: 2),
+        shadowOffset: const Offset(3, 0),
       );
       final data = LineChartData(
         minY: 0,
@@ -2575,16 +2587,27 @@ void main() {
 
       final result1 =
           verify(mockCanvasWrapper.drawRRect(captureAny, captureAny))
-            ..called(2);
-      final rRect = result1.captured[0] as RRect;
-      final paint = result1.captured[1] as Paint;
+            ..called(3);
+      final rRectShadow = result1.captured[0] as RRect;
+      final paintShadow = result1.captured[1] as Paint;
+      expect(
+        rRectShadow,
+        RRect.fromLTRBR(-28 + 3, 40, 10 + 3, 78, const Radius.circular(12)),
+      );
+      expect(paintShadow.color, const Color(0x00000000));
+      expect(
+        paintShadow.maskFilter,
+        const MaskFilter.blur(BlurStyle.normal, 5),
+      );
+      final rRect = result1.captured[2] as RRect;
+      final paint = result1.captured[3] as Paint;
       expect(
         rRect,
         RRect.fromLTRBR(-28, 40, 10, 78, const Radius.circular(12)),
       );
       expect(paint.color, const Color(0x11111111));
-      final rRectBorder = result1.captured[2] as RRect;
-      final paintBorder = result1.captured[3] as Paint;
+      final rRectBorder = result1.captured[4] as RRect;
+      final paintBorder = result1.captured[5] as Paint;
       expect(
         rRectBorder,
         RRect.fromLTRBR(-28, 40, 10, 78, const Radius.circular(12)),
@@ -2630,6 +2653,9 @@ void main() {
               .toList();
         },
         tooltipBorder: const BorderSide(color: Color(0x11111111), width: 2),
+        shadowColor: Colors.black.withOpacity(0.25),
+        shadowBlur: 4,
+        shadowOffset: const Offset(0, 3),
       );
       final data = LineChartData(
         minY: 0,
@@ -2686,16 +2712,27 @@ void main() {
 
       final result1 =
           verify(mockCanvasWrapper.drawRRect(captureAny, captureAny))
-            ..called(2);
-      final rRect = result1.captured[0] as RRect;
-      final paint = result1.captured[1] as Paint;
+            ..called(3);
+      final rRectShadow = result1.captured[0] as RRect;
+      final paintShadow = result1.captured[1] as Paint;
+      expect(
+        rRectShadow,
+        RRect.fromLTRBR(10, 40 + 3, 48, 78 + 3, const Radius.circular(12)),
+      );
+      expect(paintShadow.color, const Color(0x40000000));
+      expect(
+        paintShadow.maskFilter,
+        const MaskFilter.blur(BlurStyle.normal, 4),
+      );
+      final rRect = result1.captured[2] as RRect;
+      final paint = result1.captured[3] as Paint;
       expect(
         rRect,
         RRect.fromLTRBR(10, 40, 48, 78, const Radius.circular(12)),
       );
       expect(paint.color, const Color(0x11111111));
-      final rRectBorder = result1.captured[2] as RRect;
-      final paintBorder = result1.captured[3] as Paint;
+      final rRectBorder = result1.captured[4] as RRect;
+      final paintBorder = result1.captured[5] as Paint;
       expect(
         rRectBorder,
         RRect.fromLTRBR(10, 40, 48, 78, const Radius.circular(12)),


### PR DESCRIPTION
hi:)

this PR resolves https://github.com/imaNNeo/fl_chart/issues/1767

i've added 3 params to `LineTouchTooltipData` for tooltip shadow:
* `shadowColor` - color of the shadow
* `shadowBlur` - sigma value of mask filter blur (how much will shadow be blurred)
* `shadowOffset` - offset of the shadow (related to tooltip)

please check the image below to see example of changes:)

<img width="454" alt="image" src="https://github.com/user-attachments/assets/0b32f274-619a-439a-9acd-0e189e38cfc3">

and the code code of `LineTouchTooltipData` from example image:
```
LineTouchData get lineTouchData => LineTouchData(
        touchTooltipData: LineTouchTooltipData(
          getTooltipColor: (touchedSpot) => Colors.black,
          shadowColor: Colors.white.withOpacity(0.25),
          shadowBlur: 4,
          shadowOffset: const Offset(0, 4),
        ),
      );
```